### PR TITLE
经过投票数值平衡部分

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Copper/WildHuntWarrior.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Copper/WildHuntWarrior.cs
@@ -6,7 +6,7 @@ namespace Cynthia.Card
 {
     [CardEffectId("24016")]//狂猎战士
     public class WildHuntWarrior : CardEffect
-    {//对1个敌军单位造成3点伤害。若目标位于“刺骨冰霜”之下或被摧毁，则获得2点增益。
+    {//对1个敌军单位造成4点伤害。若目标位于“刺骨冰霜”之下或被摧毁，则获得2点增益。
         public WildHuntWarrior(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
@@ -16,7 +16,7 @@ namespace Cynthia.Card
                 return 0;
             }
             var isBoost = Game.GameRowEffect[target.PlayerIndex][target.Status.CardRow.MyRowToIndex()].RowStatus == RowStatus.BitingFrost;
-            await target.Effect.Damage(3, Card);
+            await target.Effect.Damage(4, Card);
             isBoost = isBoost || target.IsDead;
             if (isBoost)
             {

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Copper/DimeritiumShackles.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Copper/DimeritiumShackles.cs
@@ -6,7 +6,7 @@ namespace Cynthia.Card
 {
     [CardEffectId("14007")]//阻魔金镣铐
     public class DimeritiumShackles : CardEffect
-    {//改变1个单位的锁定状态。若为敌军单位，则对它造成4点伤害。
+    {//改变1个单位的锁定状态。若为敌军单位，则对它造成5点伤害。
         public DimeritiumShackles(GameCard card) : base(card) { }
         public override async Task<int> CardUseEffect()
         {
@@ -14,7 +14,7 @@ namespace Cynthia.Card
             if (result.Count <= 0) return 0;
             await result.Single().Effect.Lock(Card);
             if (result.Single().PlayerIndex != Card.PlayerIndex)
-                await result.Single().Effect.Damage(4, Card);
+                await result.Single().Effect.Damage(5, Card);
             return 0;
         }
     }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Silver/CommanderSHorn.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Silver/CommanderSHorn.cs
@@ -6,13 +6,13 @@ namespace Cynthia.Card
 {
 	[CardEffectId("13027")]//指挥号角
 	public class CommanderSHorn : CardEffect
-	{//使5个相邻单位获得3点增益。
+	{//使7个相邻单位获得3点增益。
 		public CommanderSHorn(GameCard card) : base(card){}
 		public override async Task<int> CardUseEffect()
 		{
-			var result = await Game.GetSelectPlaceCards(Card,range:2);
+			var result = await Game.GetSelectPlaceCards(Card,range:3);
 			if(result.Count<=0) return 0;
-			foreach(var card in result.Single().GetRangeCard(2).ToList())
+			foreach(var card in result.Single().GetRangeCard(3).ToList())
 			{
 				if(card.Status.CardRow.IsOnPlace())
 					await card.Effect.Boost(3,Card);

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Nilfgaard/Gold/Assassination.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Nilfgaard/Gold/Assassination.cs
@@ -6,7 +6,7 @@ namespace Cynthia.Card
 {
     [CardEffectId("32015")]//暗算
     public class Assassination : CardEffect
-    {//对1个敌军单位造成8点伤害，再对1个敌军单位造成8点伤害。
+    {//对1个敌军单位造成8点伤害，再对1个敌军单位造成9点伤害。
         public Assassination(GameCard card) : base(card) { }
         public override async Task<int> CardUseEffect()
         {
@@ -14,7 +14,7 @@ namespace Cynthia.Card
             {
                 var result = await Game.GetSelectPlaceCards(Card, selectMode: SelectModeType.EnemyRow);
                 if (result.Count <= 0) continue;
-                await result.Single().Effect.Damage(8, Card);
+                await result.Single().Effect.Damage(9, Card);
             }
             return 0;
         }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Nilfgaard/Silver/Cadaverine.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Nilfgaard/Silver/Cadaverine.cs
@@ -29,7 +29,7 @@ namespace Cynthia.Card
                 await Game.Debug($"筛选出了{targetCards.Count()}个");
                 foreach (var card in targetCards)
                 {
-                    await card.Effect.Damage(2, Card, BulletType.RedLight);
+                    await card.Effect.Damage(3, Card, BulletType.RedLight);
                 }
             }
             else if (switchCard == 1)

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Silver/VandergriftSBlade.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Silver/VandergriftSBlade.cs
@@ -6,7 +6,7 @@ namespace Cynthia.Card
 {
     [CardEffectId("43021")]//范德格里夫特之剑
     public class VandergriftSBlade : CardEffect
-    {//择一：摧毁1个铜色/银色“诅咒单位”敌军单位；或造成9点伤害，放逐所摧毁的单位。
+    {//择一：摧毁1个铜色/银色“诅咒生物”敌军单位；或造成10点伤害，放逐所摧毁的单位。
         public VandergriftSBlade(GameCard card) : base(card) { }
         public override async Task<int> CardUseEffect()
         {
@@ -31,7 +31,7 @@ namespace Cynthia.Card
                 {
                     return 0;
                 }
-                await target.Effect.Damage(9, Card);
+                await target.Effect.Damage(10, Card);
                 //如果目标没死，结束
                 if (!target.IsDead)
                 {

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Copper/TuirseachSkirmisher.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Copper/TuirseachSkirmisher.cs
@@ -16,7 +16,7 @@ namespace Cynthia.Card
                 return;
             }
 
-            await Strengthen(3, Card);
+            await Strengthen(4, Card);
         }
     }
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Silver/HolgerBlackhand.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Silver/HolgerBlackhand.cs
@@ -7,7 +7,7 @@ namespace Cynthia.Card
     [CardEffectId("63011")]//“黑手”霍格
     public class HolgerBlackhand : CardEffect
     {
-        //造成6点伤害。若摧毁目标，则使己方墓场中最强的单位获得3点强化。
+        //造成7点伤害。若摧毁目标，则使己方墓场中最强的单位获得3点强化。
         public HolgerBlackhand(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
@@ -21,7 +21,7 @@ namespace Cynthia.Card
             {
                 return 0;
             }
-            await target.Effect.Damage(6, Card);
+            await target.Effect.Damage(7, Card);
             //如果目标没死，结束
             if (!target.IsDead)
             {

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -1602,7 +1602,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Tactic,Categorie.Special},
                     Flavor = "士气加一分，听力减三分。",
-                    Info = "使5个相邻单位获得3点增益。",
+                    Info = "使7个相邻单位获得3点增益。",
                     CardArtsId = "11320700",
                 }
             },
@@ -2062,7 +2062,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Alchemy,Categorie.Special,Categorie.Item},
                     Flavor = "瑞达尼亚人将巫师的手腕拧到背后，给他戴上镣铐，并使劲晃了晃。特拉诺瓦叫喊挣扎，还弯下腰呕吐呻吟——杰洛特这才明白手铐的材质。",
-                    Info = "改变1个单位的锁定状态。若为敌军单位，则对它造成4点伤害。",
+                    Info = "改变1个单位的锁定状态。若为敌军单位，则对它造成5点伤害。",
                     CardArtsId = "11331900",
                 }
             },
@@ -3906,7 +3906,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.WildHunt,Categorie.Soldier},
                     Flavor = "白霜将至。",
-                    Info = "对1个敌军单位造成3点伤害。若目标位于“刺骨冰霜”之下或被摧毁，则获得2点增益。",
+                    Info = "对1个敌军单位造成4点伤害。若目标位于“刺骨冰霜”之下或被摧毁，则获得2点增益。",
                     CardArtsId = "13230900",
                 }
             },
@@ -4913,7 +4913,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Tactic,Categorie.Special},
                     Flavor = "“请你出手要多少钱？” “看情况喽。比如说目标是你，大改100奥伦币左右。”",
-                    Info = "对1个敌军单位造成8点伤害，再对1个敌军单位造成8点伤害。",
+                    Info = "对1个敌军单位造成8点伤害，再对1个敌军单位造成9点伤害。",
                     CardArtsId = "16310100",
                 }
             },
@@ -5334,7 +5334,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Alchemy,Categorie.Special,Categorie.Item},
                     Flavor = "我不会拿自己的性命去碰运气。我会拿上一把长剑，厚厚地涂上一层吊死鬼之毒。",
-                    Info = "择一：对1个敌军单位以及所有与它同类型的单位造成2点伤害；或摧毁1个铜色/银色“中立”单位。",
+                    Info = "择一：对1个敌军单位以及所有与它同类型的单位造成3点伤害；或摧毁1个铜色/银色“中立”单位。",
                     CardArtsId = "20154000",
                 }
             },
@@ -6229,7 +6229,7 @@ namespace Cynthia.Card
                 {
                     CardId ="42004",
                     Name="范德格里夫特",
-                    Strength=7,
+                    Strength=8,
                     Group=Group.Gold,
                     Faction = Faction.NorthernRealms,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -6841,7 +6841,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Special,Categorie.Item},
                     Flavor = "在阿德卡莱的一次骑士比武中，赛尔奇克打断了范德格里夫特的长剑。于是，愤怒的范德格里夫特下令铸造一把新的兵刃，还在上面附了强大的符文石。",
-                    Info = "择一：摧毁1个铜色/银色“诅咒单位”敌军单位；或造成9点伤害，放逐所摧毁的单位。",
+                    Info = "择一：摧毁1个铜色/银色“诅咒生物”敌军单位；或造成10点伤害，放逐所摧毁的单位。",
                     CardArtsId = "20163300",
                 }
             },
@@ -7817,7 +7817,7 @@ namespace Cynthia.Card
                 {
                     CardId ="52008",
                     Name="米尔瓦",
-                    Strength=6,
+                    Strength=8,
                     Group=Group.Gold,
                     Faction = Faction.ScoiaTael,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -8201,7 +8201,7 @@ namespace Cynthia.Card
                 {
                     CardId ="53014",
                     Name="麦莉",
-                    Strength=4,
+                    Strength=5,
                     Group=Group.Silver,
                     Faction = Faction.ScoiaTael,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -9467,7 +9467,7 @@ namespace Cynthia.Card
                 {
                     CardId ="63010",
                     Name="德莱格·波·德乌",
-                    Strength=6,
+                    Strength=7,
                     Group=Group.Silver,
                     Faction = Faction.Skellige,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -9497,7 +9497,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.ClanDimun,Categorie.Officer},
                     Flavor = "敬尼弗迦德皇帝，祝他不得善终！",
-                    Info = "造成6点伤害。若摧毁目标，则使己方墓场中最强的单位获得3点强化。",
+                    Info = "造成7点伤害。若摧毁目标，则使己方墓场中最强的单位获得3点强化。",
                     CardArtsId = "15220700",
                 }
             },
@@ -9527,7 +9527,7 @@ namespace Cynthia.Card
                 {
                     CardId ="63013",
                     Name="尤娜",
-                    Strength=6,
+                    Strength=7,
                     Group=Group.Silver,
                     Faction = Faction.Skellige,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -9887,7 +9887,7 @@ namespace Cynthia.Card
                 {
                     CardId ="64011",
                     Name="德拉蒙家族好战分子",
-                    Strength=8,
+                    Strength=9,
                     Group=Group.Copper,
                     Faction = Faction.Skellige,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -9917,7 +9917,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Soldier,Categorie.ClanTuirseach},
                     Flavor = "记好了：我们对朋友掏心窝，对敌人挥斧子。",
-                    Info = "被复活后获得3点强化。",
+                    Info = "被复活后获得4点强化。",
                     CardArtsId = "15231300",
                 }
             },
@@ -10227,7 +10227,7 @@ namespace Cynthia.Card
                 {
                     CardId ="64028",
                     Name="迪门家族海贼",
-                    Strength=3,
+                    Strength=2,
                     Group=Group.Copper,
                     Faction = Faction.Skellige,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -11019,7 +11019,7 @@ namespace Cynthia.Card
                 {
                     CardId ="70022",
                     Name = "齐齐摩工兵",
-                    Strength = 4,
+                    Strength = 5,
                     Group = Group.Copper,
                     Faction = Faction.Monsters,
                     CardUseInfo = CardUseInfo.MyRow,


### PR DESCRIPTION
指挥号角 平票 按原计划3X7实装

阻魔金镣铐
伤害4=>5

暗杀
9+9

吊死鬼之毒
伤害从2=>3

麦莉
战力+1

米尔瓦
战力6=>8

海贼
3=>2

德莱格.波.德乌
战力+1

尤娜
战力+1

黑手霍格
打6=> 7

德拉蒙好斗分子
战力8=>9

图尔塞克好斗分子
强化3=>4

范德格里夫特
战力7=>8

范德格里夫特之剑
文字修改“诅咒单位”=>“诅咒生物”
摧毁=>放逐，打9=>10

狂猎战士
+1伤害

齐齐摩工兵
4=>5