### PR TITLE
平衡第二弹

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Gold/Imlerith.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Gold/Imlerith.cs
@@ -6,7 +6,7 @@ namespace Cynthia.Card
 {
     [CardEffectId("22005")]//伊勒瑞斯
     public class Imlerith : CardEffect
-    {//对1个敌军单位造成4点伤害，若目标位于“刺骨冰霜”之下，则伤害变为8点。
+    {//对1个敌军单位造成4点伤害，若目标位于“刺骨冰霜”之下，则将其摧毁。
         public Imlerith(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
@@ -14,8 +14,15 @@ namespace Cynthia.Card
             {
                 return 0;
             }
-            int point = Game.GameRowEffect[AnotherPlayer][target.Status.CardRow.MyRowToIndex()].RowStatus == RowStatus.BitingFrost ? 8 : 4;
-            await target.Effect.Damage(point, Card);
+            //int point = Game.GameRowEffect[AnotherPlayer][target.Status.CardRow.MyRowToIndex()].RowStatus == RowStatus.BitingFrost ? 8 : 4;
+            if(Game.GameRowEffect[AnotherPlayer][target.Status.CardRow.MyRowToIndex()].RowStatus == RowStatus.BitingFrost)
+            {
+                await target.Effect.ToCemetery(CardBreakEffectType.Scorch);
+            }
+            else
+            {
+                await target.Effect.Damage(4, Card);
+            }
             return 0;
         }
     }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Gold/Ciri.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Gold/Ciri.cs
@@ -6,11 +6,12 @@ namespace Cynthia.Card
 {
     [CardEffectId("12019")]//希里
     public class Ciri : CardEffect, IHandlesEvent<AfterRoundOver>
-    {//己方输掉小局时返回手牌。 2点护甲。
+    {//获得护盾。己方输掉小局时返回手牌。 2点护甲。
         public Ciri(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
             await Card.Effect.Armor(2, Card);
+            Card.Status.IsShield = true;
             return 0;
         }
 

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Silver/FoltestSPride.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Silver/FoltestSPride.cs
@@ -6,7 +6,7 @@ namespace Cynthia.Card
 {
     [CardEffectId("43007")]//弗尔泰斯特之傲
     public class FoltestSPride : CardEffect
-    {//对1个敌军单位造成2点伤害，并将其上移一排。 驱动：再次触发此能力。
+    {//对1个敌军单位造成3点伤害，并将其上移一排。 驱动：再次触发此能力。
         public FoltestSPride(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
@@ -24,7 +24,7 @@ namespace Cynthia.Card
                     {
                         await target.Effect.Move(new CardLocation(tagetRow, 0), Card);
                     }
-                    await target.Effect.Damage(2, Card);
+                    await target.Effect.Damage(3, Card);
                 }
             }
             return 0;

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Silver/VandergriftSBlade.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Silver/VandergriftSBlade.cs
@@ -11,7 +11,7 @@ namespace Cynthia.Card
         public override async Task<int> CardUseEffect()
         {
             //卡牌描述来自https://www.bilibili.com/video/av17561142?from=search&seid=5862653946081547514 48：56
-            var switchCard = await Card.GetMenuSwitch(("一刀两断", "摧毁1个铜色/银色“诅咒单位”敌军单位。"), ("凶暴重击", "造成9点伤害，放逐所摧毁的单位"));
+            var switchCard = await Card.GetMenuSwitch(("一刀两断", "摧毁1个铜色/银色“诅咒单位”敌军单位。"), ("凶暴重击", "造成10点伤害，放逐所摧毁的单位"));
             if (switchCard == 0)
             {
                 var target = await Game.GetSelectPlaceCards(Card, 1, false,

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/ScoiaTael/Copper/HawkerHealer.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/ScoiaTael/Copper/HawkerHealer.cs
@@ -7,7 +7,7 @@ namespace Cynthia.Card
     [CardEffectId("54018")] //私枭治疗者
     public class HawkerHealer : CardEffect
     {
-        //使2个友军单位获得3点增益。
+        //使2个友军单位获得3点增益，随后将他们治愈。
         public HawkerHealer(GameCard card) : base(card)
         {
         }
@@ -19,8 +19,11 @@ namespace Cynthia.Card
             foreach (var card in cards)
             {
                 await card.Effect.Boost(boost,Card);
+                if (card.Status.HealthStatus < 0)
+                {
+                    await card.Effect.Heal(card);
+                }
             }
-
             return 0;
         }
 

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/ScoiaTael/Gold/Saesenthessis.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/ScoiaTael/Gold/Saesenthessis.cs
@@ -6,21 +6,21 @@ namespace Cynthia.Card
 {
     [CardEffectId("52002")]//萨琪亚萨司
     public class Saesenthessis : CardEffect
-    {//增益自身等同于友军“矮人”单位数量；造成等同于友军“精灵”单位数量的伤害。
+    {//增益自身等同于友军和手牌中“矮人”单位数量；造成等同于友军和手牌中“精灵”单位数量的伤害。
         public Saesenthessis(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
             var listDwarf = Game.GetPlaceCards(Card.PlayerIndex).FilterCards(filter: x => x.HasAnyCategorie(Categorie.Dwarf)).ToList();
+            var handDwarf = Game.PlayersHandCard[PlayerIndex].FilterCards(filter: x => x.HasAnyCategorie(Categorie.Dwarf)).ToList();
 
-
-            int boostNum = listDwarf.Count();
+            int boostNum = listDwarf.Count() + handDwarf.Count();
 
             await Card.Effect.Boost(boostNum, Card);
 
             var listElf = Game.GetPlaceCards(Card.PlayerIndex).FilterCards(filter: x => x.HasAnyCategorie(Categorie.Elf)).ToList();
+            var handElf = Game.PlayersHandCard[PlayerIndex].FilterCards(filter: x => x.HasAnyCategorie(Categorie.Elf)).ToList();
 
-
-            int damageNum = listElf.Count();
+            int damageNum = listElf.Count() + handElf.Count();
 
             if (damageNum == 0)
             {

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Gold/Cerys.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Gold/Cerys.cs
@@ -6,7 +6,7 @@ namespace Cynthia.Card
 {
     [CardEffectId("62007")]//凯瑞丝·奎特
     public class Cerys : CardEffect, IHandlesEvent<AfterCardResurrect>
-    {//位于墓场中时，在己方复活 4个单位后，复活单位。
+    {//位于墓场中时，在己方复活 4个单位后，复活单位，并获得1点强化。
         public Cerys(GameCard card) : base(card) { }
 
         public async Task HandleEvent(AfterCardResurrect @event)
@@ -20,6 +20,7 @@ namespace Cynthia.Card
                     await Card.Effect.Resurrect(new CardLocation() { RowPosition = Game.GetRandomCanPlayLocation(Card.PlayerIndex, true).RowPosition, CardIndex = int.MaxValue }, Card);
                     //重置计数器，复活到随机排最右侧
                     await Card.Effect.SetCountdown(value: 4);
+                    await Card.Effect.Strengthen(1, Card);
                 }
             }
             return;

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -189,7 +189,7 @@ namespace Cynthia.Card
         }
 
         //更新CardMap内容请务必将CardMapVersion更新
-        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 44);
+        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 50);
 
 
         public class MultilingualString
@@ -533,7 +533,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Cintra,Categorie.Witcher},
                     Flavor = "去往何处，何时动身，我自己说了算。",
-                    Info = "己方输掉小局时返回手牌。 2点护甲。",
+                    Info = "获得护盾。己方输掉小局时返回手牌。 2点护甲。",
                     CardArtsId = "11210100",
                 }
             },
@@ -2962,7 +2962,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.WildHunt,Categorie.Officer},
                     Flavor = "叫他们有来无回！",
-                    Info = "对1个敌军单位造成4点伤害，若目标位于“刺骨冰霜”之下，则伤害变为8点。",
+                    Info = "对1个敌军单位造成4点伤害，若目标位于“刺骨冰霜”之下，则将其摧毁。",
                     CardArtsId = "13210200",
                 }
             },
@@ -3998,7 +3998,7 @@ namespace Cynthia.Card
                 {
                     CardId ="24021",
                     Name="寒冰巨人",
-                    Strength=8,
+                    Strength=6,
                     Group=Group.Copper,
                     Faction = Faction.Monsters,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -4913,7 +4913,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Tactic,Categorie.Special},
                     Flavor = "“请你出手要多少钱？” “看情况喽。比如说目标是你，大改100奥伦币左右。”",
-                    Info = "对1个敌军单位造成8点伤害，再对1个敌军单位造成9点伤害。",
+                    Info = "对1个敌军单位造成9点伤害，再对1个敌军单位造成9点伤害。",
                     CardArtsId = "16310100",
                 }
             },
@@ -6560,7 +6560,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Machine},
                     Flavor = "正如弗尔泰斯特国王常说的那样，尺寸并不重要，关键要好用。",
-                    Info = "对1个敌军单位造成2点伤害，并将其上移一排。 驱动：再次触发此能力。",
+                    Info = "对1个敌军单位造成3点伤害，并将其上移一排。 驱动：再次触发此能力。",
                     CardArtsId = "20149400",
                 }
             },
@@ -6600,7 +6600,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Soldier,Categorie.Kaedwen},
                     Flavor = "喝酒少了欧德林，就像划船没带桨。",
-                    Info = "回合开始时，移至随机排，并使同排所有友军单位获得1点增益。",
+                    Info = "回合开始时，移至随机排，并使同排所有友军单位获得1点增益。遗愿：使同排所有友军单位获得1点增益。",
                     CardArtsId = "12221300",
                 }
             },
@@ -7696,7 +7696,7 @@ namespace Cynthia.Card
                 {
                     CardId ="52002",
                     Name="萨琪亚萨司",
-                    Strength=10,
+                    Strength=9,
                     Group=Group.Gold,
                     Faction = Faction.ScoiaTael,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -7706,7 +7706,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Aedirn,Categorie.Draconid},
                     Flavor = "我继承了父亲的变身能力……好吧，尽管我只有一种变化形态。",
-                    Info = "增益自身等同于友军“矮人”单位数量；造成等同于友军“精灵”单位数量的伤害。",
+                    Info = "增益自身等同于友军和手牌中“矮人”单位数量；造成等同于友军和手牌中“精灵”单位数量的伤害。",
                     CardArtsId = "14210100",
                 }
             },
@@ -8713,7 +8713,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Elf,Categorie.Support},
                     Flavor = "帮你包扎，没问题——只要你有钱。",
-                    Info = "使2个友军单位获得3点增益。",
+                    Info = "使2个友军单位获得3点增益，随后将他们治愈。",
                     CardArtsId = "14230100",
                 }
             },
@@ -9155,7 +9155,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.ClanAnCraite,Categorie.Officer},
                     Flavor = "大家叫我小雀鹰，知道为什么吗？因为我专治你这种鼠辈。",
-                    Info = "位于墓场中时，在己方复活4个单位后，复活此单位。",
+                    Info = "位于墓场中时，在己方复活4个单位后，复活此单位，并获得1点强化。",
                     CardArtsId = "20017700",
                 }
             },


### PR DESCRIPTION
暗算文版修正
范德剑文本修正
西格瓦尔德代码注释文本
寒冰巨人7->6

萨奇亚萨斯
10->9，伤害和增益计数方式:场上=>场上 + 手牌中

私枭治疗者
原效果 + 随后治愈该单位

凯瑞丝·奎特
+被复活后获得1点强化

欧德林
+遗愿：同排1点增益

福尔泰斯特之傲
2->3

老大锤
若位于冰霜之下摧毁

希里
+护盾