### PR TITLE
平衡调整：

### DIFF
--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Copper/Archgriffin.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Copper/Archgriffin.cs
@@ -12,6 +12,21 @@ namespace Cynthia.Card
 		{
             if (Game.GameRowEffect[PlayerIndex][Card.Status.CardRow.MyRowToIndex()].RowStatus.IsHazard())
                 await Game.GameRowEffect[PlayerIndex][Card.Status.CardRow.MyRowToIndex()].SetStatus<NoneStatus>();
+            var enemylist = Game.PlayersCemetery[Game.AnotherPlayer(Card.PlayerIndex)].Where(x => x.CardInfo().CardType == CardType.Unit && x.Status.Group == Group.Copper).ToList();
+            //如果没有铜色单位，什么都不做
+            if (enemylist.Count() == 0)
+            {
+                return 0;
+            }
+            //选择一个铜色单位，如果不选，什么都不做
+            var MoveTarget = await Game.GetSelectMenuCards(Card.PlayerIndex, enemylist.ToList(), 1);
+            if (MoveTarget.Count() == 0)
+            {
+                return 0;
+            }
+            //移动到我方墓地
+            //不清楚refresh的含义
+            await Game.ShowCardMove(new CardLocation() { RowPosition = RowPosition.EnemyCemetery, CardIndex = 0 }, MoveTarget.Single());
             return 0;
 		}
 	}

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Copper/Lamia.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Monsters/Copper/Lamia.cs
@@ -6,7 +6,7 @@ namespace Cynthia.Card
 {
     [CardEffectId("24024")]//女蛇妖
     public class Lamia : CardEffect
-    {//对1个敌军单位造成4点伤害，若目标位于“血月”之下，则伤害变为7点。
+    {//对1个敌军单位造成4点伤害，场上每有1个“血月”灾厄效果，伤害提高2点。
         public Lamia(GameCard card) : base(card) { }
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
@@ -14,8 +14,9 @@ namespace Cynthia.Card
             {
                 return 0;
             }
-            int point = Game.GameRowEffect[AnotherPlayer][target.Status.CardRow.MyRowToIndex()].RowStatus == RowStatus.BloodMoon ? 7 : 4;
-            await target.Effect.Damage(point, Card);
+            //int point = Game.GameRowEffect[AnotherPlayer][target.Status.CardRow.MyRowToIndex()].RowStatus == RowStatus.BloodMoon ? 7 : 4;
+            var count = Game.GameRowEffect.SelectMany(x => x.Select(x => x.RowStatus)).Where(x => x == RowStatus.BloodMoon).Count();
+            await target.Effect.Damage(4 + 2 * count, Card);
             return 0;
         }
     }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Gold/AleOfTheAncestors.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Neutral/Gold/AleOfTheAncestors.cs
@@ -5,15 +5,24 @@ using Alsein.Extensions;
 namespace Cynthia.Card
 {
     [CardEffectId("12009")]//先祖麦酒
-    public class AleOfTheAncestors : CardEffect
-    {//在所在排洒下“黄金酒沫”。
+    public class AleOfTheAncestors : CardEffect, IHandlesEvent<AfterTurnOver>
+    {//回合结束时，在所在排洒下“黄金酒沫”。
         public AleOfTheAncestors(GameCard card) : base(card) { }
+        /*
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
             // await Game.ApplyWeather(PlayerIndex,Card.Status.CardRow,RowStatus.GoldenFroth);
             await Game.GameRowEffect[PlayerIndex][Card.Status.CardRow.MyRowToIndex()]
                 .SetStatus<GoldenFrothStatus>();
             return 0;
+        }
+        */
+        public async Task HandleEvent(AfterTurnOver @event)
+        {
+            if (!(Card.Status.CardRow.IsOnPlace() && PlayerIndex == @event.PlayerIndex)) return;
+            await Game.GameRowEffect[PlayerIndex][Card.Status.CardRow.MyRowToIndex()]
+                .SetStatus<GoldenFrothStatus>();
+            return;
         }
     }
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Copper/DamnedSorceress.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/NorthernRealms/Copper/DamnedSorceress.cs
@@ -6,11 +6,12 @@ namespace Cynthia.Card
 {
     [CardEffectId("44025")]//中邪的女术士
     public class DamnedSorceress : CardEffect
-    {//若同排有1个“诅咒生物”单位，则造成7点伤害。
+    {//造成7点伤害，同排每有1个“诅咒生物”单位，伤害提高1点。
         public DamnedSorceress(GameCard card) : base(card) { }
         public override async Task CardDownEffect(bool isSpying, bool isReveal)
         {
             var list = Game.RowToList(PlayerIndex, Card.Status.CardRow).IgnoreConcealAndDead().Where(x => x.HasAnyCategorie(Categorie.Cursed) && x != Card);
+            /*
             if (list.Count() >= 1)
             {
                 var selectList = await Game.GetSelectPlaceCards(Card, selectMode: SelectModeType.AllRow);
@@ -19,7 +20,13 @@ namespace Cynthia.Card
                     return;
                 }
                 await target.Effect.Damage(7, Card);
+            }*/
+            var selectList = await Game.GetSelectPlaceCards(Card, selectMode: SelectModeType.AllRow);
+            if (!selectList.TrySingle(out var target))
+            {
+                return;
             }
+            await target.Effect.Damage(7 + list.Count(), Card);
             return;
         }
     }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/ScoiaTael/Gold/XavierMoran.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/ScoiaTael/Gold/XavierMoran.cs
@@ -5,23 +5,51 @@ using Alsein.Extensions;
 namespace Cynthia.Card
 {
     [CardEffectId("52003")]//泽维尔·莫兰
-    public class XavierMoran : CardEffect
-    {//增益自身等同于最后打出的非同名“矮人”单位牌的初始战力。
+    public class XavierMoran : CardEffect, IHandlesEvent<AfterRoundOver>, IHandlesEvent<AfterUnitDown>
+    {//增益自身等同于本小局打出的“矮人”单位牌的最强基础战力。
         public XavierMoran(GameCard card) : base(card) { }
+        private int boostNum = 0;
         public override async Task<int> CardPlayEffect(bool isSpying, bool isReveal)
         {
-
+            /*
             var cards = Game.HistoryList
                 .Where(x => (x.CardId.Status.CardId != Card.Status.CardId && x.CardId.CardInfo().Categories.Contains(Categorie.Dwarf)))
                             .ToList();
             if (cards.Count() <= 0) return 0;
 
             var lastDwarfCardId = cards.Last().CardId.Status.CardId;
-            var boostNum = GwentMap.CardMap[lastDwarfCardId].Strength;
+            boostNum = GwentMap.CardMap[lastDwarfCardId].Strength;
+            */
             await Card.Effect.Boost(boostNum, Card);
             return 0;
 
 
         }
+        public async Task HandleEvent(AfterUnitDown @event) //每下一个矮人打擂台
+        {
+            if (@event.Target == Card) return;
+            if (PlayerIndex == @event.Target.PlayerIndex && @event.Target.HasAllCategorie(Categorie.Dwarf))
+            {
+                if (boostNum < @event.Target.Status.Strength)
+                {
+                    await Task.Run(() => {
+
+                        boostNum = @event.Target.Status.Strength;
+
+                    });//异步运行,其实感觉不用 
+                }
+            }
+        }
+
+        public async Task HandleEvent(AfterRoundOver @event) //每小局结束清零
+        {
+            await Task.Run(() => {
+
+                boostNum = 0;
+
+            });//异步运行,其实感觉不用
+            
+        }
     }
+    
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Derive/SpectralWhale.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/CardEffects/Skellige/Derive/SpectralWhale.cs
@@ -7,8 +7,8 @@ using System.Collections.Generic;
 namespace Cynthia.Card
 {
     [CardEffectId("65004")]//幽灵鲸
-    public class SpectralWhale : CardEffect, IHandlesEvent<AfterTurnOver>
-    {//回合结束时移至随机排，对同排所有其他单位造成1点伤害。 间谍。
+    public class SpectralWhale : CardEffect, IHandlesEvent<AfterTurnOver>, IHandlesEvent<AfterCardDeath>
+    {//回合结束时移至随机排，对同排所有其他单位造成1点伤害。遗愿：再次触发此能力。间谍。
         public SpectralWhale(GameCard card) : base(card) { }
         public async Task HandleEvent(AfterTurnOver @event)
         {
@@ -47,9 +47,24 @@ namespace Cynthia.Card
                 await card.Effect.Damage(1, Card);
             }
             return;
+        }
 
-
-
+        public async Task HandleEvent(AfterCardDeath @event)
+        {
+            if (@event.Target != Card)
+            {
+                return;
+            }
+            var damagelist = Game.RowToList(Card.PlayerIndex, @event.DeathLocation.RowPosition).IgnoreConcealAndDead().Where(x => x.GetLocation().RowPosition.IsOnPlace() && x != Card).ToList();
+            if (damagelist.Count() <= 1)
+            {
+                return;
+            }
+            foreach (var card in damagelist)
+            {
+                await card.Effect.Damage(1, Card);
+            }
+            return;
         }
     }
 }

--- a/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
+++ b/src/Cynthia.Card/src/Cynthia.Card.Common/GwentGame/GwentMap.cs
@@ -189,7 +189,7 @@ namespace Cynthia.Card
         }
 
         //更新CardMap内容请务必将CardMapVersion更新
-        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 54);
+        public static Version CardMapVersion { get; } = new Version(1, 0, 0, 56);
 
 
         public class MultilingualString
@@ -328,7 +328,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{},
                     Flavor = "富克斯家族的传奇创始人波罗斯因为酗酒丢了性命。当时他的金戒指掉进了一条小溪，他去捞的时候晕了过去。",
-                    Info = "在所在排洒下“黄金酒沫”。",
+                    Info = "己方回合结束时，在所在排洒下“黄金酒沫”。",
                     CardArtsId = "20024400",
                 }
             },
@@ -3653,7 +3653,7 @@ namespace Cynthia.Card
                 {
                     CardId ="24004",
                     Name="大狮鹫",
-                    Strength=10,
+                    Strength=9,
                     Group=Group.Copper,
                     Faction = Faction.Monsters,
                     CardUseInfo = CardUseInfo.MyRow,
@@ -3663,7 +3663,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Beast},
                     Flavor = "大狮鹫也是狮鹫，只是更加凶悍。",
-                    Info = "移除所在排的灾厄。",
+                    Info = "移除所在排的灾厄。从对方墓场中1张铜色单位牌移至己方墓场。",
                     CardArtsId = "13230700",
                 }
             },
@@ -4069,7 +4069,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Beast},
                     Flavor = "有个迷信的家伙用蜡堵住耳朵，结果什么也听不到，包括警告——他的船直接撞上了礁石。",
-                    Info = "对1个敌军单位造成4点伤害，若目标位于“血月”之下，则伤害变为7点。",
+                    Info = "对1个敌军单位造成4点伤害，场上每有1个“血月”灾厄效果，伤害提高2点。",
                     CardArtsId = "13240900",
                 }
             },
@@ -7345,7 +7345,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Mage,Categorie.Cursed},
                     Flavor = "萨宾娜的诅咒谁也不放过，就连其他的女术士也难以幸免。",
-                    Info = "若同排有1个“诅咒生物”单位，则造成7点伤害。",
+                    Info = "造成7点伤害，同排每有1个“诅咒生物”单位，伤害提高1点。",
                     CardArtsId = "20163000",
                 }
             },
@@ -7726,7 +7726,7 @@ namespace Cynthia.Card
                     IsDerive = false,
                     Categories = new Categorie[]{ Categorie.Dwarf},
                     Flavor = "怎么了，公主？吃不惯野味吗？嗯？",
-                    Info = "增益自身等同于最后打出的非同名“矮人”单位牌的初始战力。",
+                    Info = "增益自身等同于本小局打出的“矮人”单位牌的最强基础战力。",
                     CardArtsId = "20008000",
                 }
             },
@@ -10438,7 +10438,7 @@ namespace Cynthia.Card
                     IsDerive = true,
                     Categories = new Categorie[]{ Categorie.Cursed,Categorie.Token},
                     Flavor = "“呃，座头鲸应该没那么大。那是头长须鲸。”“嘴那么短的长须鲸？你被药草冲昏了头吗！”",
-                    Info = "回合结束时移至随机排，对同排所有其他单位造成1点伤害。 间谍。",
+                    Info = "回合结束时移至随机排，对同排所有其他单位造成1点伤害。遗愿：再次触发此能力。间谍。",
                     CardArtsId = "15240300",
                 }
             },


### PR DESCRIPTION
幽灵鲸
遗愿：同排

大狮鹫
原效果 + 移动对方墓场一个铜色单位
（老效果思路）
10->9

女蛇妖
7打4，场上每有一道血月伤害+2

先祖麦酒
+回合结束后

中邪的女术士
+同排其他诅咒单位数量的伤害

泽维尔·莫兰
=>增益自身等同于本小局打出的最强的“矮人”单位牌的基础战力。